### PR TITLE
Indentation fixup

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,3 +1,4 @@
-((nil . ((clojure-indent-style . 'align-arguments)
+((nil . ((clojure-indent-style . always-indent)
+         (eval . (put-clojure-indent :require 0))
          (cider-ns-refresh-before-fn . "development/stop")
          (cider-ns-refresh-after-fn  . "development/go"))))

--- a/src/dev/user.clj
+++ b/src/dev/user.clj
@@ -1,13 +1,13 @@
 (ns user
   (:require
-   [clojure.pprint :refer [pprint]]
-   [clojure.spec.alpha :as s]
-   [clojure.tools.namespace.repl
-    :as tools-ns
-    :refer [disable-reload! refresh clear set-refresh-dirs]]
-   [com.example.components.middleware]
-   [expound.alpha :as expound]
-   [taoensso.timbre :as log]))
+    [clojure.pprint :refer [pprint]]
+    [clojure.spec.alpha :as s]
+    [clojure.tools.namespace.repl
+     :as tools-ns
+     :refer [disable-reload! refresh clear set-refresh-dirs]]
+    [com.example.components.middleware]
+    [expound.alpha :as expound]
+    [taoensso.timbre :as log]))
 
 (set-refresh-dirs "src/main" "src/test" "src/dev" "src/example")
 
@@ -19,9 +19,9 @@
    (if (System/getProperty "dev")
      [(fn [{:keys [level vargs] :as data}]
         (if (and (= :debug level)
-                 (= "=>" (second vargs)))
+              (= "=>" (second vargs)))
           (update-in data [:vargs 2]
-                     #(with-out-str (clojure.pprint/pprint %)))
+            #(with-out-str (clojure.pprint/pprint %)))
           data))]
      [])})
 

--- a/src/example/com/example/components/datomic.clj
+++ b/src/example/com/example/components/datomic.clj
@@ -1,22 +1,22 @@
 (ns com.example.components.datomic
   (:require
-   [com.fulcrologic.rad.database-adapters.db-adapter :as dba]
-   [com.fulcrologic.rad.database-adapters.protocols :as dbp]
-   [com.fulcrologic.rad.database-adapters.datomic :as datomic-adapter]
-   [com.example.schema :refer [prior-schema latest-schema]]
-   [taoensso.timbre :as log]
-   [datomic.api :as d]
-   [datomock.core :refer [mock-conn]]
-   [mount.core :refer [defstate]]
-   [com.example.components.config :refer [config]]
-   [clojure.string :as str]))
+    [com.fulcrologic.rad.database-adapters.db-adapter :as dba]
+    [com.fulcrologic.rad.database-adapters.protocols :as dbp]
+    [com.fulcrologic.rad.database-adapters.datomic :as datomic-adapter]
+    [com.example.schema :refer [prior-schema latest-schema]]
+    [taoensso.timbre :as log]
+    [datomic.api :as d]
+    [datomock.core :refer [mock-conn]]
+    [mount.core :refer [defstate]]
+    [com.example.components.config :refer [config]]
+    [clojure.string :as str]))
 
 (defn config->datomic-url [{::keys [config]}]
   (let [{:postgres/keys [user host port password database]
          datomic-db     :datomic/database} config]
     (format "datomic:sql://%s?jdbc:postgresql://%s%s/%s?user=%s&password=%s"
-            datomic-db host (when port (str ":" port)) database
-            user password)))
+      datomic-db host (when port (str ":" port)) database
+      user password)))
 
 (defn presence
   "Returns s if s is not blank. Takes an optional default."
@@ -41,29 +41,30 @@
   []
   (log/info "Starting Datomic")
   (let [url                    (presence (System/getenv "DATOMIC_URL")
-                                         (config->datomic-url config))
+                                 (config->datomic-url config))
         ;; TODO: Better system of dealing with migrations
         created?               (d/create-database url)
         mocking-required?      (boolean (System/getProperty
-                                         "force.mocked.connection"))
+                                          "force.mocked.connection"))
         mocking-ok?            (or mocking-required?
-                                   (boolean (System/getProperty
-                                             "allow.mocked.connection")))
+                                 (boolean (System/getProperty
+                                            "allow.mocked.connection")))
         conn                   (if mocking-required?
                                  (mock-conn (d/db (d/connect url)))
                                  (d/connect url))
         adapter                (datomic-adapter/->DatomicAdapter :production conn)
         migration              (dbp/diff->migration adapter prior-schema
-                                                    latest-schema)]
+                                 latest-schema)]
     (log/warn "Datomic URL: " url)
     (when created?
       (log/info "New Datomic database created: " :main))
     (when mocking-required?
       (log/warn "USING A MOCKED CONNECTION. No changes to the database will persist.")
       (when-not mocking-ok?
-        (throw (ex-info (str "REFUSING TO START a database that has SNAPSHOT "
-                             "migrations. Please set allow.mocked.connection "
-                             "JVM property if you want to allow this.") {}))))
+        (throw (ex-info (str
+                          "REFUSING TO START a database that has SNAPSHOT "
+                          "migrations. Please set allow.mocked.connection "
+                          "JVM property if you want to allow this.") {}))))
     (log/info "Running Migrations")
     (try
       (d/transact conn [#:db{:fn {:db.fn/lang     :clojure
@@ -71,7 +72,7 @@
                                   :db.fn/requires []
                                   :db.fn/params   '[db eid rel ident]
                                   :db.fn/code migration-code}
-                                        ;:id    #db/id[:db.part/user -1000005]
+                             ;; :id #db/id[:db.part/user -1000005]
                              :ident :com.fulcrologic.rad.fn/add-ident}])
       (d/transact conn migration)
       (catch Exception e


### PR DESCRIPTION
Previous PR was merged quickly. This will fix the indentation in
previous PR but more importantly add some configs to mimic your
indentation setup from Emacs. These will be applied for any
contributors using that editor.