### PR TITLE
 Ignore CSRF token if undefined in script 

### DIFF
--- a/src/main/com/fulcrologic/rad/application.cljc
+++ b/src/main/com/fulcrologic/rad/application.cljc
@@ -83,7 +83,7 @@
     (merge
       #?(:clj {}
          :cljs
-              (let [token (when-not (undefined? js/fulcro_network_csrf_token)
+              (let [token (when (exists? js/fulcro_network_csrf_token)
                             js/fulcro_network_csrf_token)]
                 {:remotes {:remote (net/fulcro-http-remote {:url                "/api"
                                                             :request-middleware (secured-request-middleware {:csrf-token token})})}}))

--- a/src/main/com/fulcrologic/rad/application.cljc
+++ b/src/main/com/fulcrologic/rad/application.cljc
@@ -30,7 +30,7 @@
     ::fs/config})
 
 (defn elision-predicate
-  "Returns an elision predicate that will return false if the keyword k is in the blacklist or has the namespace
+  "Returns an elision predicate that will return true if the keyword k is in the blacklist or has the namespace
   `ui`."
   [blacklist]
   (fn [k]


### PR DESCRIPTION
`undefined?` still throws an error if JS variable was never defined; `exists?` will quietly ignore the missing CSRF token.

I also fixed the `elision-predicate` docstring in the same PR. Hope that's not a problem. :)