### PR TITLE
Better args checking of defsc-report

### DIFF
--- a/src/main/com/fulcrologic/rad/form.cljc
+++ b/src/main/com/fulcrologic/rad/form.cljc
@@ -1242,5 +1242,5 @@
           [save-form delete-entity]))
 
 (comment
-  (opts/resolve-key {} `com.fulcrologic.rad.form-options/field-options)
-  )
+  (opts/resolve-key {} `com.fulcrologic.rad.form-options/field-options))
+

--- a/src/main/com/fulcrologic/rad/report.cljc
+++ b/src/main/com/fulcrologic/rad/report.cljc
@@ -456,6 +456,8 @@
          `(do
             ~@defs)))))
 
+#?(:clj (s/fdef defsc-report :args ::comp/args))
+
 (def reload!
   "[report-instance]
 


### PR DESCRIPTION
Reused args checking from `defsc` which makes most sense to me since it is (also) a defsc. Now it fails with

> Invalid arguments. [:arglist] is invalid.

which is perhaps  not immediately clear but much better than before.