### PR TITLE
Fix built-in :int formatter spec error

### DIFF
--- a/src/main/com/fulcrologic/rad/report.cljc
+++ b/src/main/com/fulcrologic/rad/report.cljc
@@ -536,7 +536,7 @@
                :timestamp       (fn [_ value] (dt/tformat "MMM d, yyyy h:mma" value))
                :date            (fn [_ value] (dt/tformat "MMM d, yyyy" value))
                :time            (fn [_ value] (dt/tformat "h:mma" value))}
-     :int     {:default (fn [_ value] (math/numeric->str value))}
+     :int     {:default (fn [_ value] (str value))}
      :decimal {:default    (fn [_ value] (math/numeric->str value))
                :currency   (fn [_ value] (math/numeric->str (math/round value 2)))
                :percentage (fn [_ value] (math/numeric->percent-str value))


### PR DESCRIPTION
We cannot use math/numeric->str for an int b/c it requires a bigdecimal (unless `*primitive*` false) and will thus throw a spec error.