### PR TITLE
Make Pathom error visible to :remote-error? etc

### DIFF
--- a/src/main/com/fulcrologic/rad/application.cljc
+++ b/src/main/com/fulcrologic/rad/application.cljc
@@ -70,7 +70,9 @@
   [pred]
   (fn [ast]
     (let [mutation? (symbol? (:dispatch-key ast))]
-      (cond-> (elide-ast-nodes ast pred)
+      (cond-> (-> ast
+                  (elide-ast-nodes pred)
+                  (update :children conj (eql/expr->ast :com.wsscode.pathom.core/errors)))
         mutation? (update :children conj (eql/expr->ast :tempids))))))
 
 (defn fulcro-rad-app


### PR DESCRIPTION
When a resolver throws an error, `:com.wsscode.pathom.core/errors` (a map from attribute to `#:com.fulcrologic.rad.pathom{:errors {:message ..., :data ...}`) is in the body of the response. This change makes it visible to the rest of the code, such as a custom `:remote-error?` (under (-> result :body ::p/errors)).