### PR TITLE
Add support for :string attributes to id-string->id

### DIFF
--- a/src/main/com/fulcrologic/rad/ids.cljc
+++ b/src/main/com/fulcrologic/rad/ids.cljc
@@ -55,12 +55,13 @@
 
 (defn id-string->id
   "When forms are routed to their ID is in the URL as a string. This converts IDs in such a string format to the
-   given type (which must be a RAD type name that supports IDs like :uuid, :int, or :long)."
+   given type (which must be a RAD type name that supports IDs like :uuid, :int, :long or :string)."
   [type id]
   (case type
     :uuid (new-uuid id)
     :int (int/parse-int id)
     :long (int/parse-long id)
+    :string id
     (do
       (log/error "Unsupported ID type" type)
       id)))


### PR DESCRIPTION
Function id-string->id is used to translate from string representation
of ID in routing/navigation to actual id type.

It is trivial to add for :string identity attributes, as this transformation
is just an identity.

This function has one call-site (checked fulcro-rad, fulcro-rad-sql, fulcro-rad-datomic)
and there doesn't seem to be any other special support code that needs to be added.

I know working with legacy projects is not a priority, but having `:string` IDs supported goes a long way
on legacy projects (I can pack composite keys and such into a string and unpack them in a resolver).