### PR TITLE
Add support for ::pc/transform in `attribute-resolver`

### DIFF
--- a/src/main/com/fulcrologic/rad/attributes_options.cljc
+++ b/src/main/com/fulcrologic/rad/attributes_options.cljc
@@ -153,6 +153,16 @@
   "
   :com.wsscode.pathom.connect/input)
 
+(def pc-transform
+  "ALIAS to :com.wsscode.pathom.connect/transform.
+   See the pathom transform docs: https://blog.wsscode.com/pathom/#connect-transform
+
+   Allows one to specify a function that receives the full resolver/mutation map and returns the final version.
+
+   Generally used to wrap the resolver/mutation function with some generic operation to augment its data or operations.
+  "
+  :com.wsscode.pathom.connect/transform)
+
 (def read-only?
   "Boolean or `(fn [form-instance attribute] boolean?)`. If true it indicates to the form and db layer that writes
    of this value should not be allowed.  Enforcement is an optional feature. See you database adapter and rendering

--- a/src/main/com/fulcrologic/rad/resolvers.cljc
+++ b/src/main/com/fulcrologic/rad/resolvers.cljc
@@ -42,19 +42,22 @@
   or nil."
   [attr]
   [::attr/attribute => (? ::pc/resolver)]
-  (enc/when-let [resolver (::pc/resolve attr)
+  (enc/when-let [resolver        (::pc/resolve attr)
                  secure-resolver (fn [env input]
                                    (->>
                                      (resolver env input)
                                      (auth/redact env)))
-                 k (::attr/qualified-key attr)
-                 output [k]]
+                 k               (::attr/qualified-key attr)
+                 output          [k]]
     (log/info "Building attribute resolver for" (::attr/qualified-key attr))
-    (merge
-      {::pc/output output}
-      (just-pc-keys attr)
-      {::pc/sym     (symbol (str k "-resolver"))
-       ::pc/resolve secure-resolver})))
+    (let [transform (::pc/transform attr)]
+      (cond-> (merge
+                {::pc/output output}
+                (just-pc-keys attr)
+                {::pc/sym     (symbol (str k "-resolver"))
+                 ::pc/resolve secure-resolver})
+        transform transform
+        ))))
 
 (>defn generate-resolvers
   "Generate resolvers for attributes that directly define pathom ::pc/resolve keys"


### PR DESCRIPTION
Similar to [fulcro-rad-datomic PR 10](https://github.com/fulcrologic/fulcro-rad-datomic/pull/10).

This PR adds the ability to specify a `::pc/transform` in an attribute with a custom `pc-resolve`.

Tested manually on my project. 