### PR TITLE
Hiding a subform

### DIFF
--- a/src/main/com/fulcrologic/rad/form.cljc
+++ b/src/main/com/fulcrologic/rad/form.cljc
@@ -138,17 +138,23 @@
         field-style (or (get field-styles qualified-key) field-style)]
     (if field-style
       (fn [env attr _] (render-field env attr))
-      (let [{::keys [ui layout-styles]} (get subforms qualified-key)
-            {target-styles ::layout-styles} (comp/component-options ui)
-            {::app/keys [runtime-atom]} (comp/any->app form-instance)
-            element      :ref-container
-            layout-style (or
-                           (get layout-styles element)
-                           (get target-styles element)
-                           :default)
-            render-fn    (some-> runtime-atom deref ::rad/controls ::element->style->layout
-                           (get-in [element layout-style]))]
-        render-fn))))
+      (let [{::keys [ui layout-styles subform-visible?]} (get subforms qualified-key)
+            subform-visible? (if (fn? subform-visible?)
+                               (subform-visible? form-instance)
+                               subform-visible?)]
+        (if subform-visible?
+          (let [{target-styles ::layout-styles} (comp/component-options ui)
+                {::app/keys [runtime-atom]} (comp/any->app form-instance)
+                element      :ref-container
+                layout-style (or
+                               (get layout-styles element)
+                               (get target-styles element)
+                               :default)
+                render-fn    (some-> runtime-atom deref ::rad/controls ::element->style->layout
+                                     (get-in [element layout-style]))]
+            render-fn)
+          (fn [env attr]
+            nil))))))
 
 (defn master-form
   "Return the master form for the given component instance."

--- a/src/main/com/fulcrologic/rad/form.cljc
+++ b/src/main/com/fulcrologic/rad/form.cljc
@@ -138,12 +138,8 @@
         field-style (or (get field-styles qualified-key) field-style)]
     (if field-style
       (fn [env attr _] (render-field env attr))
-      (let [{::keys [ui layout-styles subform-visible?]} (get subforms qualified-key)
-            subform-visible? (cond
-                               (fn? subform-visible?) (subform-visible? form-instance)
-                               (nil? subform-visible?) true
-                               :else subform-visible?)]
-        (if subform-visible?
+      (let [{::keys [ui layout-styles field-visible?]} (get subforms qualified-key)]
+        (if (?! field-visible? form-instance)
           (let [{target-styles ::layout-styles} (comp/component-options ui)
                 {::app/keys [runtime-atom]} (comp/any->app form-instance)
                 element      :ref-container

--- a/src/main/com/fulcrologic/rad/form.cljc
+++ b/src/main/com/fulcrologic/rad/form.cljc
@@ -139,9 +139,10 @@
     (if field-style
       (fn [env attr _] (render-field env attr))
       (let [{::keys [ui layout-styles subform-visible?]} (get subforms qualified-key)
-            subform-visible? (if (fn? subform-visible?)
-                               (subform-visible? form-instance)
-                               subform-visible?)]
+            subform-visible? (cond
+                               (fn? subform-visible?) (subform-visible? form-instance)
+                               (nil? subform-visible?) true
+                               :else subform-visible?)]
         (if subform-visible?
           (let [{target-styles ::layout-styles} (comp/component-options ui)
                 {::app/keys [runtime-atom]} (comp/any->app form-instance)

--- a/src/main/com/fulcrologic/rad/form_options.cljc
+++ b/src/main/com/fulcrologic/rad/form_options.cljc
@@ -223,11 +223,6 @@
    the subform."
   :com.fulcrologic.rad.form/ui)
 
-(def subform-visible?
-  "A boolean? or `(fn [this] boolean?).`
-  Used within `subforms`. Whether or not to render the `ui`."
-  :com.fulcrologic.rad.form/subform-visible?)
-
 (def field-style-config
   "ATTRIBUTE OPTION: A map of options that are used by the rendering plugin to augment the style of a rendered input.
   Such configuration options are really up to the render plugin, but could include things like `:input/props` as

--- a/src/main/com/fulcrologic/rad/form_options.cljc
+++ b/src/main/com/fulcrologic/rad/form_options.cljc
@@ -223,6 +223,11 @@
    the subform."
   :com.fulcrologic.rad.form/ui)
 
+(def subform-visible?
+  "A boolean? or `(fn [this] boolean?).`
+  Used within `subforms`. Whether or not to render the `ui`."
+  :com.fulcrologic.rad.form/subform-visible?)
+
 (def field-style-config
   "ATTRIBUTE OPTION: A map of options that are used by the rendering plugin to augment the style of a rendered input.
   Such configuration options are really up to the render plugin, but could include things like `:input/props` as


### PR DESCRIPTION
I've called the option `fo/subform-visible?` rather than `fo/field-visible?` because I think of a field a scalar thing. And `fo/field-visible?` is expressly for an attribute and is related to `fo/fields-visible?`. Three reasons this new option is a completely different thing that needs a new name. 
You said you would accept a lambda, but this option also allows a boolean.