### PR TITLE
Autoadd :tempids to mutation responses

### DIFF
--- a/src/main/com/fulcrologic/rad/application.cljc
+++ b/src/main/com/fulcrologic/rad/application.cljc
@@ -69,11 +69,9 @@
   "Returns an EQL transform that removes `(pred k)` keywords from network requests."
   [pred]
   (fn [ast]
-    (let [mutation? (symbol? (:dispatch-key ast))]
-      (cond-> (-> ast
-                  (elide-ast-nodes pred)
-                  (update :children conj (eql/expr->ast :com.wsscode.pathom.core/errors)))
-        mutation? (update :children conj (eql/expr->ast :tempids))))))
+    (-> ast
+        (elide-ast-nodes pred)
+        (update :children conj (eql/expr->ast :com.wsscode.pathom.core/errors)))))
 
 (defn fulcro-rad-app
   "Create a new fulcro RAD application with reasonable defaults.

--- a/src/main/com/fulcrologic/rad/pathom.clj
+++ b/src/main/com/fulcrologic/rad/pathom.clj
@@ -124,7 +124,8 @@
   {::p/mutate  pc/mutate
    ::p/env     {::p/reader               [p/map-reader pc/reader2 pc/index-reader
                                           pc/open-ident-reader p/env-placeholder-reader]
-                ::p/placeholder-prefixes #{">"}}
+                ::p/placeholder-prefixes #{">"}
+                ::pc/mutation-join-globals [:tempids]}
    ::p/plugins (into []
                  (keep identity
                    (concat


### PR DESCRIPTION
Instead of manually adding :tempids to mutations on the client side,
we can leverage Pathom's config to do it automatically on the server
side.

Fixes fulcrologic/fulcro#484 for RAD.

Tested with rad-demo: with only the application change, saving a form is "broken" (the app still believes it is unsaved). Adding the pathom change fixes that again.