### PR TITLE
Add enum formatter to report built-in formatters

### DIFF
--- a/src/main/com/fulcrologic/rad/report.cljc
+++ b/src/main/com/fulcrologic/rad/report.cljc
@@ -659,6 +659,9 @@
                :date            (fn [_ value] (dt/tformat "MMM d, yyyy" value))
                :month-day       (fn [_ value] (dt/tformat "MMM d" value))
                :time            (fn [_ value] (dt/tformat "h:mma" value))}
+     :enum    {:default (fn [_ value _ column-attribute]
+                          (if-let [labels (::attr/enumerated-labels column-attribute)]
+                              (labels value) (str value)))}
      :int     {:default (fn [_ value] (str value))}
      :decimal {:default    (fn [_ value] (math/numeric->str value))
                :currency   (fn [_ value] (math/numeric->str (math/round value 2)))


### PR DESCRIPTION
Adds formatter for `:enum` in report `built-in` formatters.