### PR TITLE
Convert html-date of "" to nil date object

### DIFF
--- a/src/main/com/fulcrologic/rad/type_support/date_time.cljc
+++ b/src/main/com/fulcrologic/rad/type_support/date_time.cljc
@@ -12,6 +12,7 @@
   "
   #?(:cljs (:require-macros [com.fulcrologic.rad.type-support.date-time]))
   (:require
+    [clojure.string :as str]
     [clojure.spec.alpha :as s]
     [com.fulcrologic.rad.locale :as locale]
     [com.fulcrologic.guardrails.core :refer [>defn >def => ?]]
@@ -148,8 +149,8 @@
 (>defn html-date-string->local-date
   "Convert a standard HTML5 date input string to a local date"
   [s]
-  [string? => (? date?)]
-  (when-not (= "" s)
+  [(? string?) => (? date?)]
+  (when-not (str/blank? s)
     (ld/parse s)))
 
 (>defn local-date->html-date-string
@@ -238,12 +239,12 @@
 
 (>defn html-datetime-string->inst
   ([date-time-string]
-   [string? => inst?]
+   [(? string?) => (? inst?)]
    (html-datetime-string->inst *current-zone-name* date-time-string))
   ([zone-name date-time-string]
-   [(? ::zone-name) string? => (? inst?)]
+   [(? ::zone-name) (? string?) => (? inst?)]
    (try
-     (when-not (= "" date-time-string)
+     (when-not (str/blank? date-time-string)
        (let [z (get-zone-id zone-name)
              dt (ldt/parse date-time-string)
              zdt (ldt/at-zone dt z)
@@ -331,11 +332,10 @@
     (tformat "yyyy-MM-dd" (now))))
 
 (>defn html-date->inst
-  "Convert an HTML date input string to an inst at the given local time, adjusted to the correct *current-timezone*. Returns
-   `now` if the string isn't a proper ISO string."
+  "Convert an HTML date input string to an inst at the given local time, adjusted to the correct *current-timezone*."
   [html-date local-time]
   [(? string?) ::local-time => (? inst?)]
-  (when-not (= "" html-date)
+  (when-not (str/blank? html-date)
     (let [date      (or (ld/parse html-date) (ld/now))
           date-time (ld/at-time date local-time)]
       (local-datetime->inst date-time))))

--- a/src/main/com/fulcrologic/rad/type_support/date_time.cljc
+++ b/src/main/com/fulcrologic/rad/type_support/date_time.cljc
@@ -148,8 +148,9 @@
 (>defn html-date-string->local-date
   "Convert a standard HTML5 date input string to a local date"
   [s]
-  [string? => date?]
-  (ld/parse s))
+  [string? => (? date?)]
+  (when-not (= "" s)
+    (ld/parse s)))
 
 (>defn local-date->html-date-string
   "Convert a standard HTML5 date input string to a local date"
@@ -240,13 +241,14 @@
    [string? => inst?]
    (html-datetime-string->inst *current-zone-name* date-time-string))
   ([zone-name date-time-string]
-   [(? ::zone-name) string? => inst?]
+   [(? ::zone-name) string? => (? inst?)]
    (try
-     (let [z   (get-zone-id zone-name)
-           dt  (ldt/parse date-time-string)
-           zdt (ldt/at-zone dt z)
-           i   (zdt/to-instant zdt)]
-       (new-date (instant/to-epoch-milli i)))
+     (when-not (= "" date-time-string)
+       (let [z (get-zone-id zone-name)
+             dt (ldt/parse date-time-string)
+             zdt (ldt/at-zone dt z)
+             i (zdt/to-instant zdt)]
+         (new-date (instant/to-epoch-milli i))))
      (catch #?(:cljs :default :clj Exception) e
        nil))))
 
@@ -332,10 +334,11 @@
   "Convert an HTML date input string to an inst at the given local time, adjusted to the correct *current-timezone*. Returns
    `now` if the string isn't a proper ISO string."
   [html-date local-time]
-  [(? string?) ::local-time => inst?]
-  (let [date      (or (ld/parse html-date) (ld/now))
-        date-time (ld/at-time date local-time)]
-    (local-datetime->inst date-time)))
+  [(? string?) ::local-time => (? inst?)]
+  (when-not (= "" html-date)
+    (let [date      (or (ld/parse html-date) (ld/now))
+          date-time (ld/at-time date local-time)]
+      (local-datetime->inst date-time))))
 
 (>defn zoned-date-time->inst
   "Convert a zoned-date-time back to a low-level inst?"

--- a/src/test/com/fulcrologic/rad/type_support/date_time_spec.cljc
+++ b/src/test/com/fulcrologic/rad/type_support/date_time_spec.cljc
@@ -52,7 +52,10 @@
     "Converts an ISO string into a LocalDate"
     (dt/html-date-string->local-date "2019-03-01") => (ld/of 2019 3 1)
     "Can convert LocalDate to an HTML input string"
-    (dt/local-date->html-date-string (ld/of 2019 3 1)) => "2019-03-01"))
+    (dt/local-date->html-date-string (ld/of 2019 3 1)) => "2019-03-01"
+    "Empty string and nil HTML input string return nil LocalDate"
+    (dt/html-date-string->local-date "") => nil
+    (dt/html-date-string->local-date nil) => nil))
 
 (specification "local-datetime string conversion"
   (let [la-1130 (dt/local-datetime->inst "America/Los_Angeles" 4 1 2019 11 30)]
@@ -63,8 +66,11 @@
       (dt/html-datetime-string->inst "2019-04-01T11:30") => la-1130
       "Can convert an instant into a localized time string"
       (dt/inst->html-datetime-string "America/Los_Angeles" la-1130) => "2019-04-01T11:30:00"
-      "Converts an ISO string into a LocalDate"
-      (dt/html-datetime-string->inst "America/Los_Angeles" "2019-04-01T11:30") => la-1130)))
+      "Converts an ISO string into an instant"
+      (dt/html-datetime-string->inst "America/Los_Angeles" "2019-04-01T11:30") => la-1130
+      "Empty string and nil HTML input string return nil instant"
+      (dt/html-datetime-string->inst "") => nil
+      (dt/html-datetime-string->inst nil) => nil)))
 
 (specification "inst->local-datetime"
   (let [tm          (datetime/new-date (instant/to-epoch-milli (cljc.java-time.instant/parse "2019-03-05T12:00:00Z")))
@@ -137,7 +143,10 @@
       (datetime/set-timezone! "America/Los_Angeles")
       (assertions
         "LA"
-        (datetime/html-date->inst dt tm) => #inst "2020-03-01T14:00:00Z"))))
+        (datetime/html-date->inst dt tm) => #inst "2020-03-01T14:00:00Z")))
+  "Empty string and nil HTML input string return nil instant"
+  (dt/html-date->inst "" (lt/now)) => nil
+  (dt/html-date->inst nil (lt/now)) => nil)
 
 (specification "inst->zoned-date-time"
   (let [expected (zdt/of (ldt/of (ld/of 2020 3 1) (lt/of 6 0)) (datetime/get-zone-id "America/Los_Angeles"))]


### PR DESCRIPTION
These functions are used in fulcro-rad-semantic-ui in date pickers. When
using the "clear" button on date picker, the value in the field becomes "".

"" represents an empty value in date picker, so it would make sense that these
html-date-> parsing functions should be able to handle "" and convert it to nil.

Currently they throw a parsing error. Solves part of https://github.com/fulcrologic/fulcro-rad-semantic-ui/issues/18