### PR TITLE
Update pom.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.10.1</version>
+      <version>1.10.3</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
@@ -76,17 +76,12 @@
     <dependency>
       <groupId>com.fulcrologic</groupId>
       <artifactId>guardrails</artifactId>
-      <version>1.1.7</version>
+      <version>1.1.10</version>
     </dependency>
     <dependency>
       <groupId>edn-query-language</groupId>
       <artifactId>eql</artifactId>
       <version>1.0.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fulcrologic</groupId>
-      <artifactId>colossal-squuid</artifactId>
-      <version>0.1.1</version>
     </dependency>
     <dependency>
       <groupId>com.taoensso</groupId>
@@ -106,17 +101,22 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojurescript</artifactId>
-      <version>1.10.866</version>
+      <version>1.10.914</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yetanalytics</groupId>
+      <artifactId>colossal-squuid</artifactId>
+      <version>0.1.3</version>
     </dependency>
     <dependency>
       <groupId>com.fulcrologic</groupId>
       <artifactId>fulcro</artifactId>
-      <version>3.5.6</version>
+      <version>3.5.10</version>
     </dependency>
     <dependency>
       <groupId>cljc.java-time</groupId>
       <artifactId>cljc.java-time</artifactId>
-      <version>0.1.17</version>
+      <version>0.1.18</version>
     </dependency>
     <dependency>
       <groupId>com.taoensso</groupId>


### PR DESCRIPTION
Fixes an issue where the old versions of transitive deps, such as cljc.java-time end up on the classpath, instead of the versions that are actually declared in `deps.edn`.

For context, see this thread in Clojurians Slack: https://clojurians.slack.com/archives/C03S1L9DN/p1644487265112059