### PR TITLE
Use merge/merge-component to initialize form ui props after :event/loaded

### DIFF
--- a/src/main/com/fulcrologic/rad/form.cljc
+++ b/src/main/com/fulcrologic/rad/form.cljc
@@ -949,13 +949,14 @@
   (let [{::keys [initialize-ui-props]} (comp/component-options FormClass)]
     (if initialize-ui-props
       (let [denorm-props    (fns/ui->props state-map FormClass form-ident)
+            primary-key     (comp/component-options FormClass ::id)
             predefined-keys (set (keys denorm-props))
             ui-props        (?! initialize-ui-props FormClass denorm-props)
             all-keys        (set (keys ui-props))
             ;; Ensure that the user's function cannot possible conflict with form state
-            allowed-keys    (set/difference all-keys predefined-keys)
+            allowed-keys    (conj (set/difference all-keys predefined-keys) primary-key)
             ui-entity       (select-keys ui-props allowed-keys)]
-        (uism/apply-action env update-in form-ident merge ui-entity))
+        (uism/apply-action env merge/merge-component FormClass ui-entity))
       env)))
 
 (defstatemachine form-machine

--- a/src/main/com/fulcrologic/rad/form.cljc
+++ b/src/main/com/fulcrologic/rad/form.cljc
@@ -947,11 +947,14 @@
   "Return denormalized `initialize-ui-props` for form and its subforms"
   [state-map FormClass denorm-props]
   (let [{::keys [id initialize-ui-props subforms]} (comp/component-options FormClass)
+        primary-key      (::attr/qualified-key id)
         predefined-keys (set (keys denorm-props))
         ui-props        (?! initialize-ui-props FormClass denorm-props)
         all-keys        (set (keys ui-props))
-        allowed-keys    (conj (set/difference all-keys predefined-keys) id)
-        ui-entity       (select-keys ui-props allowed-keys)]
+        allowed-keys    (set/difference all-keys predefined-keys)
+        ui-entity       (assoc (select-keys ui-props allowed-keys)
+                               primary-key (get denorm-props primary-key))]
+
     (reduce-kv
       (fn [ui-entity subform-key subform-def]
         (if-not (contains? denorm-props subform-key)


### PR DESCRIPTION
The patch changes `form/handle-user-ui-props` 

- use merge/merge-component to normalize data
- takes subforms into account

Closes #84.