### PR TITLE
fix: missing path-params after route-denied

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
  :deps    {edn-query-language/eql            {:mvn/version "1.0.2"}
            com.taoensso/timbre               {:mvn/version "4.10.0"}
            com.taoensso/encore               {:mvn/version "2.120.0"}
-           com.fulcrologic/fulcro            {:mvn/version "3.6.0-RC2"}
+           com.fulcrologic/fulcro            {:mvn/version "3.6.2"}
            com.fulcrologic/fulcro-i18n       {:mvn/version "1.0.0"}
            com.fulcrologic/guardrails        {:mvn/version "1.1.11"}
            commons-codec/commons-codec       {:mvn/version "1.15"}

--- a/src/main/com/fulcrologic/rad/form.cljc
+++ b/src/main/com/fulcrologic/rad/form.cljc
@@ -459,11 +459,11 @@
         base-options               (merge
                                      {::validator        (attr/make-attribute-validator attributes)
                                       ::control/controls standard-controls
-                                      :route-denied      (fn [this relative-root proposed-route]
+                                      :route-denied      (fn [this relative-root proposed-route timeouts-and-params]
                                                            #?(:cljs
                                                               (when-let [confirm-fn (or (comp/component-options (get-class) ::confirm) js/confirm)]
                                                                 (when (confirm-fn "You will lose unsaved changes. Are you sure?")
-                                                                  (dr/retry-route! this relative-root proposed-route)))))}
+                                                                  (dr/retry-route! this relative-root proposed-route timeouts-and-params)))))}
                                      options
                                      (cond->
                                        {:ident           (fn [_ props] [id-key (get props id-key)])


### PR DESCRIPTION
While investing a bug I realized that it was only happening when I was leaving a form in a dirty state. The reason was that retry-route! was called without any params, so the route-params passed by the user action were lost.
This goes with https://github.com/fulcrologic/fulcro/pull/537