### PR TITLE
Change to a more compatible JS construct

### DIFF
--- a/src/main/com/fulcrologic/rad/application.cljc
+++ b/src/main/com/fulcrologic/rad/application.cljc
@@ -94,7 +94,7 @@
     (merge
       #?(:clj {}
          :cljs
-         (let [token (when-not (undefined? js/fulcro_network_csrf_token)
+         (let [token (when (exists? js/fulcro_network_csrf_token)
                        js/fulcro_network_csrf_token)]
            {:remotes {:remote (net/fulcro-http-remote {:url                "/api"
                                                        :request-middleware (secured-request-middleware {:csrf-token token})})}}))


### PR DESCRIPTION
I'm running into CI problem where the JS construct `(void 0 === fulcro_csrf_token)` does not properly determine that the var does not exist. Instead, the construct `(typeof fulcro_csrf_token !== "undefined")` is more appropriate, and is represented by `cljs.core/exists?`. 