### PR TITLE
Add missing line breaks in the developer guide

### DIFF
--- a/docs/DevelopersGuide.adoc
+++ b/docs/DevelopersGuide.adoc
@@ -505,7 +505,10 @@ The core predefined attribute types include (this list is not complete yet, but 
 `:string`:: A variable-length string.
 `:enum`:: An enumerated list of values.
 Support varies by db adapter.
-`:boolean`:: true/false `:int`:: A (typically 32-bit) integer `:long`:: A (typically 64-bit) integer `:decimal`:: An arbitrary-precision decimal number.
+`:boolean`:: true/false 
+`:int`:: A (typically 32-bit) integer 
+`:long`:: A (typically 64-bit) integer 
+`:decimal`:: An arbitrary-precision decimal number. 
 Stored precision is up to the db adapter.
 `:instant`:: A binary UTC timestamp.
 `:keyword`:: An EDN keyword `:symbol`:: An EDN symbol `:ref`:: A reference to another entity/table/document.


### PR DESCRIPTION
In the developer guide, there are some missing line breaks.

Before:
![image](https://github.com/fulcrologic/fulcro-rad/assets/2965273/5a2986f2-f953-41ce-a8bf-109bf7275df0)

After:
![image](https://github.com/fulcrologic/fulcro-rad/assets/2965273/c8b4f7e8-15a4-4af5-9bd9-21ddc3318968)
