### PR TITLE
allow enumerated labels values as fn in reports

### DIFF
--- a/src/main/com/fulcrologic/rad/report.cljc
+++ b/src/main/com/fulcrologic/rad/report.cljc
@@ -750,7 +750,8 @@
                             (some-> value (name) str/capitalize)))}
      :enum    {:default (fn [_ value _ column-attribute]
                           (if-let [labels (::attr/enumerated-labels column-attribute)]
-                            (labels value) (str value)))}
+                            (?! (labels value))
+                            (str value)))}
      :int     {:default (fn [_ value] (str value))}
      :decimal {:default    (fn [_ value] (math/numeric->str value))
                :currency   (fn [_ value] (math/numeric->str (math/round value 2)))


### PR DESCRIPTION
this allows for instance to have ao/enumerated-labels such as

```clojure
(def student-statuses  {"active" #(tr "active")
                        "invited" #(tr "invited")})
```