### PR TITLE
fix: completion-fn called twice in will-enter on initial page load

### DIFF
--- a/src/main/com/fulcrologic/rad/form.cljc
+++ b/src/main/com/fulcrologic/rad/form.cljc
@@ -1296,6 +1296,9 @@
                               (do
                                 (when-let [confirm-fn (or user-confirm #?(:cljs js/confirm))]
                                   (when (confirm-fn "You will lose unsaved changes. Are you sure?")
+                                    (if (::replace-route? timeouts-and-params)
+                                     (history/replace-route! fulcro-app route timeouts-and-params)
+                                     (history/push-route! fulcro-app route timeouts-and-params))
                                     (dr/retry-route! (comp/class->any fulcro-app Form) Root route timeouts-and-params)))
                                 env))))}
 


### PR DESCRIPTION
At least on Chrome, the browser sends an initial pop state event
that has no state, and does not correspond to the expected `forward`
or `backward` distinction handled by the pop-state-listener. As a
result, installing the htlm5-history triggers a routing event, that
is then immediatly followed by another when one restores the history,
which is the common use case in RAD.