### PR TITLE
Update DevelopersGuide.adoc

### DIFF
--- a/docs/DevelopersGuide.adoc
+++ b/docs/DevelopersGuide.adoc
@@ -211,9 +211,9 @@ The standard in RAD is for libraries to define an `*-options` namespace that def
 This allows these vars to be used instead of raw keywords, leading to much easier development.
 
 For example, the `attributes` namespace defines
-https://github.com/fulcrologic/fulcro-rad/blob/develop/src/main/com/fulcrologic/rad/attributes_options.cljc[`attributes-options`].
+https://github.com/fulcrologic/fulcro-rad/blob/main/src/main/com/fulcrologic/rad/attributes_options.cljc[`attributes-options`].
 This namespace includes all of the legal keys that RAD *itself* defines that can be placed in an attribute's map.
-The `form` namespace defines https://github.com/fulcrologic/fulcro-rad/blob/develop/src/main/com/fulcrologic/rad/form_options.cljc[`form-options`], etc.
+The `form` namespace defines https://github.com/fulcrologic/fulcro-rad/blob/main/src/main/com/fulcrologic/rad/form_options.cljc[`form-options`], etc.
 
 This allows you to write an attribute like so:
 


### PR DESCRIPTION
Relinked forms-options and attributes-options. Were linked to /devel/ branch before, which doest exist anymore. Point to /main branch now.