### PR TITLE
Remove double exit when silent abandon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@ docs/.asciidoctor
 .guardrails-pro
 assets
 lsp
+.lsp
 .clj-kondo

--- a/src/main/com/fulcrologic/rad/form.cljc
+++ b/src/main/com/fulcrologic/rad/form.cljc
@@ -478,8 +478,6 @@
         silent-abandon? (?! (comp/component-options this ::silent-abandon?) this)
         machine         (get-in state-map [::uism/asm-id form-ident])]
     (when machine
-      (when silent-abandon?
-        (abandon-form! this form-ident))
       (uism/trigger! master-form form-ident :event/exit {}))
     true))
 


### PR DESCRIPTION
When the `silent-abandon` option is enabled, leaving a dirty form will exit the state machine twice. This causes an error:

```
ERROR [com.fulcrologic.fulcro.ui-state-machines:?] -  Attempted to trigger event  Object on state machine Object , but that state machine has not been started (call begin! first). See https://book.fulcrologic.com/#err-uism-trigger-not-started-machine
```

This PR fixes that problem by removing the extra exit.