### PR TITLE
Add derived calculations to form load prior to editing.

### DIFF
--- a/src/main/com/fulcrologic/rad/form.cljc
+++ b/src/main/com/fulcrologic/rad/form.cljc
@@ -1213,6 +1213,7 @@
                (uism/apply-action fs/add-form-config* FormClass form-ident {:destructive? true})
                (uism/apply-action fs/mark-complete* form-ident)
                (cond-> route-pending? (route-target-ready form-ident))
+               (apply-derived-calculations)
                (uism/activate :state/editing))))}
         :event/failed
         {::uism/handler


### PR DESCRIPTION
Add derived calculations to form load prior to editing

This PR enhances the form loading process by performing derived calculations before the editing phase begins. This ensures that all computed values are available when the user starts editing a form, providing a more consistent user experience.

