### PR TITLE
Lint defauthenticator as def instead of defn

### DIFF
--- a/src/clj-kondo/clj-kondo.exports/com.fulcrologic/fulcro-rad/config.edn
+++ b/src/clj-kondo/clj-kondo.exports/com.fulcrologic/fulcro-rad/config.edn
@@ -1,5 +1,5 @@
 {:lint-as {com.fulcrologic.rad.attributes/defattr             clojure.core/def
-           com.fulcrologic.rad.authorization/defauthenticator clojure.core/defn
+           com.fulcrologic.rad.authorization/defauthenticator clojure.core/def
            com.fulcrologic.rad.blob/defblobattr               clojure.core/def
            com.fulcrologic.rad.container/defsc-container      clojure.core/defn
            com.fulcrologic.rad.form/defsc-form                clojure.core/defn


### PR DESCRIPTION
This is the same configuration as in fulcro:
https://github.com/fulcrologic/fulcro/blob/7a4999f99d9e5a6a659a4873c9a9e8d01a768675/src/clj-kondo/clj-kondo.exports/com.fulcrologic/fulcro/config.edn#L18

We discovered that in certain situations clj-kondo would report an error when using defauthenticator: "Invalid function body.". I traced this back to clj-kondo configs getting loaded in a different order. Specifically, if the fulcro-rad config is loaded after the fulcro config, we see this error, because fulcro-rad's config wins.

The fix is linting defauthenticator to lint as def here so that the configs don't conflict and the order does not matter.