### PR TITLE
fix docs example for `ao/valid?`

### DIFF
--- a/docs/DevelopersGuide.adoc
+++ b/docs/DevelopersGuide.adoc
@@ -1194,7 +1194,8 @@ Attribute-level validation checks can be specified with a predicate:
 [source]
 ----
 (defattr name :account/name :string
-  {ao/valid? (fn [nm] (boolean (seq nm)))})
+  {ao/valid? (fn [value _props _qualified-key]
+               (boolean (seq value)))})
 ----
 
 Custom validations are defined at the form level with the `::form/validator` key.


### PR DESCRIPTION
Minor update to documentation to have the correct function signature for `ao/valid` according to its docstring.