### PR TITLE
Fix a typo in clj-kondo config.edn (option-utils -> options-util)

### DIFF
--- a/src/clj-kondo/clj-kondo.exports/com.fulcrologic/fulcro-rad/config.edn
+++ b/src/clj-kondo/clj-kondo.exports/com.fulcrologic/fulcro-rad/config.edn
@@ -5,5 +5,5 @@
            com.fulcrologic.rad.form/defsc-form                clojure.core/defn
            com.fulcrologic.rad.form/defunion                  clojure.core/def
            com.fulcrologic.rad.form/with-field-context        clojure.core/let
-           com.fulcrologic.rad.option-utils/defoption         clojure.core/def
+           com.fulcrologic.rad.options-util/defoption         clojure.core/def
            com.fulcrologic.rad.report/defsc-report            clojure.core/defn}}


### PR DESCRIPTION
Hi,
I noticed that clj-kondo reports `fro/style` as undefined, but the REPL evaluated values with no problems.

When I investigated the issue, I noticed that field-render-options uses new macro `defoption` from new namespace `c.f.r.options-utils`. Unfortunately this namespace was misspelled in clj-kondo's config.edn. 

This pull request fixes the spelling. 