### PR TITLE
Fix incorrect attribute key in filtered-attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-test:
+tests:
 	shadow-cljs compile ci-tests
 	karma start --single-run
 	clojure -A:dev:tests:clj-tests

--- a/src/main/com/fulcrologic/rad/form/impl.cljc
+++ b/src/main/com/fulcrologic/rad/form/impl.cljc
@@ -303,7 +303,7 @@
    that match `(pred attribute)`"
   [form-class pred]
   (let [attributes        (or
-                            (comp/component-options form-class ::attr/attributes)
+                            (comp/component-options form-class ::form/attributes)
                             [])
         local-optional    (into #{} (comp (filter pred) (map ::attr/qualified-key)) attributes)
         children          (some->> form-class comp/get-query eql/query->ast :children (keep :component))


### PR DESCRIPTION
Use ::form/attributes instead of ::attr/attributes when looking up form component options, matching the correct namespace for form attributes.

difference in where we keep the GR schema and the qualified keyword we use to extract stuff